### PR TITLE
[2022/07/12] - HTTP/S Request 응답 메뉴 구현

### DIFF
--- a/app/components/Button.js
+++ b/app/components/Button.js
@@ -2,25 +2,37 @@ import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 
-function Button({ children, buttonPurpose }) {
-  return <ButtonWrapper type={buttonPurpose}>{children}</ButtonWrapper>;
-}
+const Button = ({ children, buttonType, primary, handleButtonClick }) => {
+  return (
+    <ButtonWrapper
+      primary={primary}
+      type={buttonType}
+      onClick={handleButtonClick}
+    >
+      {children}
+    </ButtonWrapper>
+  );
+};
 
 const ButtonWrapper = styled.button`
-  margin-left: 1rem;
-  width: 8rem;
+  width: ${(props) => (props.primary ? "8rem" : "12rem")};
+  margin-left: ${(props) => (props.primary ? "1rem" : "auto")};
   font-size: 1.2rem;
-  background-color: rgb(14, 99, 156);
+  font-weight: 500;
+  background-color: ${(props) =>
+    props.primary ? "rgb(14, 99, 156)" : "var(--vscode-input-background)"};
   transition: background-color 0.2s ease-in-out;
 
   :hover {
-    background-color: rgba(14, 99, 156, 0.5);
+    background-color: ${(props) => props.primary && "rgb(14, 99, 156)"};
   }
 `;
 
 Button.propTypes = {
   children: PropTypes.node,
-  buttonPurpose: PropTypes.string,
+  buttonType: PropTypes.string,
+  primary: PropTypes.bool,
+  handleButtonClick: PropTypes.func,
 };
 
 export default Button;

--- a/app/constants/options.js
+++ b/app/constants/options.js
@@ -1,0 +1,24 @@
+export const LOADER_CSS_OPTIONS = {
+  opacity: "0.85",
+};
+
+export const EDITOR_OPTIONS = {
+  tabSize: 2,
+  smoothScrolling: true,
+  renderWhitespace: true,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+};
+
+export const REQUEST_RAW_BODY_EDITOR_OPTIONS = {
+  tabSize: 2,
+  readOnly: false,
+  smoothScrolling: true,
+  renderWhitespace: true,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+};
+
+export const READ_ONLY_TRUE_OPTION = { readOnly: true, lineNumbers: "on" };
+export const READ_ONLY_FALSE_OPTION = { readOnly: false, lineNumbers: "on" };
+export const LINE_NUMBER_OPTION = { readOnly: true, lineNumbers: "off" };

--- a/app/features/Response/Copy/ResponseCopyIcon.js
+++ b/app/features/Response/Copy/ResponseCopyIcon.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { FiCopy } from "react-icons/fi";
+import styled from "styled-components";
+
+import useResponseDataStore from "../../../store/useResponseDataStore";
+import vscode from "../../../vscode";
+
+const ResponseCopyIcon = () => {
+  const { data } = useResponseDataStore((state) => state.responseData);
+
+  const handleCopyIconClick = () => {
+    vscode.postMessage({ purpose: "Alert Copy" });
+
+    navigator.clipboard.writeText(data);
+  };
+
+  return (
+    <CopyIconWrapper>
+      <FiCopy className="copyIcon" onClick={handleCopyIconClick} />
+    </CopyIconWrapper>
+  );
+};
+
+const CopyIconWrapper = styled.div`
+  margin-left: auto;
+
+  .copyIcon {
+    font-size: 1.3rem;
+    margin-right: 1.7rem;
+    transition: all 0.2s ease-in-out;
+    cursor: pointer;
+
+    :hover {
+      opacity: 0.7;
+      transform: scale(1.15);
+    }
+  }
+`;
+
+export default ResponseCopyIcon;

--- a/app/features/Response/Menu/ResponseMenu.js
+++ b/app/features/Response/Menu/ResponseMenu.js
@@ -21,10 +21,6 @@ const ResponseMenu = () => {
     shallow,
   );
 
-  const handleOptionChange = (event) => {
-    handleResponseOptionChange(event.target.innerText);
-  };
-
   return (
     <>
       <DetailOption>
@@ -35,7 +31,13 @@ const ResponseMenu = () => {
                 currentOption={responseOption}
                 menuOption={responseMenuOption}
               >
-                <h3 onClick={handleOptionChange}>{responseMenuOption}</h3>
+                <h3
+                  onClick={(event) =>
+                    handleResponseOptionChange(event.target.innerText)
+                  }
+                >
+                  {responseMenuOption}
+                </h3>
               </MenuOption>
               {responseMenuOption === HEADERS && (
                 <p>({responseData.headersLength})</p>

--- a/app/features/Response/Panel/ResponsePanel.js
+++ b/app/features/Response/Panel/ResponsePanel.js
@@ -1,22 +1,39 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
+import shallow from "zustand/shallow";
 
 import Loader from "../../../components/Loader";
-import { RESPONSE } from "../../../constants/response";
+import { ERROR, RESPONSE } from "../../../constants/response";
 import { FINISHED, LOADING } from "../../../constants/shared";
 import useResponseDataStore from "../../../store/useResponseDataStore";
-import ResponseEmptyMenu from "../EmptyResponse/EmptyResponse";
+import ResponseEmptyMenu from "../Empty/ResponseEmptyMenu";
+import ResponseErrorMenu from "../Error/ResponseErrorMenu";
 import ResponseMenu from "../Menu/ResponseMenu";
 
 const ResponsePanel = () => {
-  const { requestInProcess, handleResponseData, handleRequestProcessStatus } =
-    useResponseDataStore((state) => state);
+  const {
+    responseData,
+    requestInProcess,
+    handleResponseData,
+    handleRequestProcessStatus,
+  } = useResponseDataStore(
+    (state) => ({
+      responseData: state.responseData,
+      requestInProcess: state.requestInProcess,
+      handleResponseData: state.handleResponseData,
+      handleRequestProcessStatus: state.handleRequestProcessStatus,
+    }),
+    shallow,
+  );
 
   const handleExtensionMessage = (event) => {
-    // if (event.data.type === RESPONSE) {
-    //   handleResponseData(event.data);
-    //   handleRequestProcessStatus(FINISHED);
-    // }
+    if (event.data.type === RESPONSE) {
+      handleResponseData(event.data);
+      handleRequestProcessStatus(FINISHED);
+    } else if (event.data.type === ERROR) {
+      handleResponseData(event.data);
+      handleRequestProcessStatus(ERROR);
+    }
   };
 
   useEffect(() => {
@@ -30,6 +47,12 @@ const ResponsePanel = () => {
       return (
         <ResponsePanelWrapper>
           <ResponseMenu />
+        </ResponsePanelWrapper>
+      );
+    case ERROR:
+      return (
+        <ResponsePanelWrapper>
+          <ResponseErrorMenu {...responseData} />
         </ResponsePanelWrapper>
       );
     default:

--- a/app/features/Response/Preview/ResponseDataPreview.js
+++ b/app/features/Response/Preview/ResponseDataPreview.js
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+
+const ResponsePreview = ({ sourceCode }) => {
+  return (
+    <IframeWrapper>
+      <iframe srcDoc={sourceCode} />
+    </IframeWrapper>
+  );
+};
+
+const IframeWrapper = styled.div`
+  width: 100%;
+  height: 65vh;
+
+  iframe {
+    width: 100%;
+    height: 65vh;
+    background: white;
+    overflow: scroll;
+  }
+`;
+
+ResponsePreview.propTypes = {
+  sourceCode: PropTypes.string,
+};
+
+export default ResponsePreview;

--- a/app/shared/CodeEditor.js
+++ b/app/shared/CodeEditor.js
@@ -1,0 +1,112 @@
+import Editor from "@monaco-editor/react";
+import PropTypes from "prop-types";
+import React, { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+import { EDITOR_HEIGHT, FORM_HEIGHT } from "../constants/height";
+import {
+  EDITOR_OPTIONS,
+  LINE_NUMBER_OPTION,
+  READ_ONLY_FALSE_OPTION,
+  READ_ONLY_TRUE_OPTION,
+} from "../constants/options";
+import { RAW } from "../constants/request";
+import { PREVIEW, TEXT, THEME } from "../constants/response";
+import { JSON } from "../constants/shared";
+import ResponsePreview from "../features/Response/Preview/ResponseDataPreview";
+import useRequestStore from "../store/useRequestStore";
+import useResponseOptionStore from "../store/useResponseOptionStore";
+
+const CodeEditor = ({ requestFormValue, responseValue, requestForm }) => {
+  const editorRef = useRef(null);
+  const { responseOption, responseBodyOption, responseBodyViewFormat } =
+    useResponseOptionStore((state) => state);
+  const [editorLanguage, setEditorLanguage] = useState(
+    responseBodyViewFormat.toLowerCase(),
+  );
+  const {
+    bodyOption,
+    handleBodyRawData,
+    shouldBeautifyEditor,
+    handleBeautifyButton,
+  } = useRequestStore((state) => state);
+
+  const handleEditorOnMount = (editor) => {
+    editorRef.current = editor;
+  };
+
+  function handleRequestBodyEditorChange(bodyValue) {
+    handleBodyRawData(bodyValue);
+  }
+
+  useEffect(() => {
+    if (requestForm) {
+      if (shouldBeautifyEditor) {
+        handleBeautifyButton();
+
+        setTimeout(async () => {
+          await editorRef.current
+            .getAction("editor.action.formatDocument")
+            .run();
+        }, 300);
+      }
+    }
+  }, [bodyOption, shouldBeautifyEditor]);
+
+  useEffect(() => {
+    if (requestForm) return;
+    if (responseBodyOption === "Preview") return;
+
+    if (editorRef.current?.getValue() !== responseValue) {
+      editorRef.current?.setValue(responseValue);
+    }
+
+    if (responseBodyOption !== RAW) {
+      setTimeout(async () => {
+        editorRef.current.updateOptions(READ_ONLY_FALSE_OPTION);
+
+        await editorRef.current.getAction("editor.action.formatDocument").run();
+
+        editorRef.current.updateOptions(READ_ONLY_TRUE_OPTION);
+      }, 300);
+
+      setEditorLanguage(responseBodyViewFormat.toLowerCase());
+    } else {
+      setTimeout(() => {
+        editorRef.current.updateOptions(LINE_NUMBER_OPTION);
+      }, 300);
+
+      setEditorLanguage(TEXT);
+    }
+  }, [responseOption, responseBodyOption, responseBodyViewFormat]);
+
+  return (
+    <EditorWrapper>
+      {responseBodyOption === PREVIEW && !requestForm ? (
+        <ResponsePreview sourceCode={responseValue} />
+      ) : (
+        <Editor
+          height={requestForm ? FORM_HEIGHT : EDITOR_HEIGHT}
+          language={requestForm ? JSON : editorLanguage}
+          theme={THEME}
+          value={requestForm ? requestFormValue : responseValue}
+          options={EDITOR_OPTIONS}
+          onChange={requestForm && handleRequestBodyEditorChange}
+          onMount={handleEditorOnMount}
+        />
+      )}
+    </EditorWrapper>
+  );
+};
+
+const EditorWrapper = styled.div`
+  margin-top: 2rem;
+`;
+
+CodeEditor.propTypes = {
+  responseValue: PropTypes.string,
+  requestFormValue: PropTypes.string,
+  requestForm: PropTypes.bool,
+};
+
+export default CodeEditor;


### PR DESCRIPTION
## Summary
- 버튼 컴포넌트 props 추가로 받게 리팩토링
- Response 정보 복사 할 수 있는 기능 구현
- Response 코드 리팩토링
- CodeEditor options 상수화 파일 생성
- Reusable CodeEditor 컴포넌트 구현



### preview 1
![2022-07-12 22 33 13](https://user-images.githubusercontent.com/83770081/178502670-2412fad7-73b1-4cac-b9fb-a3cbc003234e.gif)

<br>
<br>

### preview 2
![2022-07-12 22 33 45](https://user-images.githubusercontent.com/83770081/178502681-f54e5622-66af-41b9-bd7f-54b71009ab02.gif)
