### PR TITLE
[2022/07/13] - Request body raw code editor 구현

### DIFF
--- a/app/components/Button.js
+++ b/app/components/Button.js
@@ -16,7 +16,7 @@ const Button = ({ children, buttonType, primary, handleButtonClick }) => {
 
 const ButtonWrapper = styled.button`
   width: ${(props) => (props.primary ? "8rem" : "12rem")};
-  margin-left: ${(props) => (props.primary ? "1rem" : "auto")};
+  margin-left: ${(props) => (props.primary ? "1rem" : "2.7rem")};
   font-size: 1.2rem;
   font-weight: 500;
   background-color: ${(props) =>

--- a/app/components/InputWrapper.js
+++ b/app/components/InputWrapper.js
@@ -18,7 +18,7 @@ const InputWrapperContainer = styled.div`
   }
 
   input {
-    border: 0.1rem solid var(--default-text);
+    border: 0.1rem solid rgba(255, 255, 255, 0.5);
     border-radius: 0.3rem;
     padding: 0.5rem 0.7rem;
     font-size: 1.2rem;

--- a/app/components/Loader.js
+++ b/app/components/Loader.js
@@ -2,18 +2,16 @@ import React from "react";
 import { PropagateLoader } from "react-spinners";
 import styled from "styled-components";
 
-const Loader = () => {
-  const css = {
-    opacity: "0.85",
-  };
+import { LOADER_CSS_OPTIONS } from "../constants/options";
 
+const Loader = () => {
   return (
     <LoaderWrapper>
       <PropagateLoader
         color="var(--vscode-foreground)"
         speedMultiplier="1"
-        size="22"
-        cssOverride={css}
+        size="22px"
+        cssOverride={LOADER_CSS_OPTIONS}
       />
     </LoaderWrapper>
   );

--- a/app/components/Message.js
+++ b/app/components/Message.js
@@ -11,7 +11,7 @@ const MessageWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: ${(props) => (props.primary ? "1.5rem" : " 3.8rem")};
+  margin-top: ${(props) => (props.primary ? "1rem" : " 3.8rem")};
 
   h2 {
     margin: 1.3rem 0;
@@ -26,6 +26,7 @@ const MessageWrapper = styled.div`
   p {
     margin: 1rem 0;
     opacity: 0.65;
+    line-height: 1.1;
   }
 
   img {

--- a/app/components/SelectWrapper.js
+++ b/app/components/SelectWrapper.js
@@ -2,9 +2,9 @@ import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 
-const SelectWrapper = ({ children, requestMenu }) => {
+const SelectWrapper = ({ children, requestMenu, primary }) => {
   return (
-    <SelectWrapperContainer border={requestMenu}>
+    <SelectWrapperContainer primary={primary} border={requestMenu}>
       {children}
     </SelectWrapperContainer>
   );
@@ -13,6 +13,7 @@ const SelectWrapper = ({ children, requestMenu }) => {
 const SelectWrapperContainer = styled.div`
   display: flex;
   align-items: center;
+  margin-left: ${(props) => props.primary && "auto"};
   padding-bottom: ${(props) => (props.border ? "0.8rem" : "")};
   border-bottom: ${(props) =>
     props.border ? "0.08rem solid rgba(255, 255, 255, 0.3)" : ""};
@@ -25,6 +26,7 @@ const SelectWrapperContainer = styled.div`
 SelectWrapper.propTypes = {
   children: PropTypes.node,
   requestMenu: PropTypes.bool,
+  primary: PropTypes.bool,
 };
 
 export default SelectWrapper;

--- a/app/components/Wrapper.js
+++ b/app/components/Wrapper.js
@@ -9,8 +9,8 @@ const Wrapper = ({ children }) => {
 const ComponentWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  margin-top: 3.5rem;
   height: 35vh;
 `;
 

--- a/app/constants/request.js
+++ b/app/constants/request.js
@@ -2,6 +2,7 @@ export const GET = "Get";
 export const RAW = "Raw";
 export const GZIP = "gzip";
 export const NONE = "None";
+export const TOKEN = "token";
 export const PARAMS = "Params";
 export const ACCEPT = "Accept";
 export const METHOD = "Method";
@@ -9,6 +10,8 @@ export const REQUEST = "Request";
 export const DEFLATE = "deflate";
 export const NO_AUTH = "No Auth";
 export const ANY_MIME_TYPE = "*/*";
+export const PASSWORD = "password";
+export const USERNAME = "username";
 export const NO_CACHE = "no-cache";
 export const AUTH = "Authorization";
 export const FORM_DATA = "Form Data";
@@ -29,7 +32,15 @@ export const REQUEST_MENU_OPTIONS = [
   "Body",
   "Options",
 ];
-
+export const REQUEST_BODY_RAW_OPTIONS = [
+  { option: "Text", headerField: "text/plain" },
+  { option: "JavaScript", headerField: "application/javascript" },
+  {
+    option: "JSON",
+    headerField: "application/json",
+  },
+  { option: "HTML", headerField: "text/html" },
+];
 export const REQUEST_BODY_OPTIONS = [
   { option: "None", headerField: "" },
   { option: "Form Data", headerField: "multipart/form-data" },
@@ -37,5 +48,5 @@ export const REQUEST_BODY_OPTIONS = [
     option: "x-www-form-urlencoded",
     headerField: "application/x-www-form-urlencoded",
   },
-  { option: "Raw", headerField: "application/json" },
+  { option: "Raw", headerField: "text/plain" },
 ];

--- a/app/features/Request/Authorization/RequestAuthBearerToken.js
+++ b/app/features/Request/Authorization/RequestAuthBearerToken.js
@@ -3,13 +3,14 @@ import shallow from "zustand/shallow";
 
 import InputWrapper from "../../../components/InputWrapper";
 import Wrapper from "../../../components/Wrapper";
+import { TOKEN } from "../../../constants/request";
 import useRequestStore from "../../../store/useRequestStore";
 
 const RequestAuthBearerToken = () => {
-  const { authDataToken, handleRequestTokenData } = useRequestStore(
+  const { authDataToken, handleRequestAuthData } = useRequestStore(
     (state) => ({
       authDataToken: state.authData.token,
-      handleRequestTokenData: state.handleRequestTokenData,
+      handleRequestAuthData: state.handleRequestAuthData,
     }),
     shallow,
   );
@@ -17,13 +18,13 @@ const RequestAuthBearerToken = () => {
   return (
     <Wrapper>
       <InputWrapper>
-        <label htmlFor="token">Token</label>
+        <label htmlFor="token">Token:</label>
         <input
-          placeholder="token"
           name="token"
+          placeholder="token"
           className="authInputBox"
           value={authDataToken}
-          onChange={(event) => handleRequestTokenData(event.target.value)}
+          onChange={(event) => handleRequestAuthData(TOKEN, event.target.value)}
         />
       </InputWrapper>
     </Wrapper>

--- a/app/features/Request/Authorization/RequestAuthSelectMenu.js
+++ b/app/features/Request/Authorization/RequestAuthSelectMenu.js
@@ -11,6 +11,7 @@ const RequestAuthSelectMenu = () => {
   const { authOption, handleRequestAuthType } = useRequestStore(
     (state) => ({
       authOption: state.authOption,
+      authData: state.authData,
       handleRequestAuthType: state.handleRequestAuthType,
     }),
     shallow,

--- a/app/features/Request/Authorization/RequestBasicAuth.js
+++ b/app/features/Request/Authorization/RequestBasicAuth.js
@@ -1,52 +1,61 @@
-import React, { useState } from "react";
+import React from "react";
 import shallow from "zustand/shallow";
 
 import InputWrapper from "../../../components/InputWrapper";
 import Wrapper from "../../../components/Wrapper";
+import { PASSWORD, USERNAME } from "../../../constants/request";
 import useRequestStore from "../../../store/useRequestStore";
 
 const RequestBasicAuth = () => {
-  const [shouldShowPassword, setShouldShowPassword] = useState(false);
-  const { authData, handleRequestUsernameData, handleRequestPasswordData } =
-    useRequestStore(
-      (state) => ({
-        authData: state.authData,
-        handleRequestUsernameData: state.handleRequestUsernameData,
-        handleRequestPasswordData: state.handleRequestPasswordData,
-      }),
-      shallow,
-    );
-
-  const handlePasswordDisplayOption = () => {
-    setShouldShowPassword((state) => !state);
-  };
+  const {
+    authData,
+    handleRequestAuthData,
+    shouldShowPassword,
+    handleShouldShowPassword,
+  } = useRequestStore(
+    (state) => ({
+      authData: state.authData,
+      handleRequestAuthData: state.handleRequestAuthData,
+      shouldShowPassword: state.shouldShowPassword,
+      handleShouldShowPassword: state.handleShouldShowPassword,
+    }),
+    shallow,
+  );
 
   return (
     <Wrapper>
       <InputWrapper>
-        <label htmlFor="username">Username</label>
+        <label htmlFor="username">Username:</label>
         <input
           type="text"
-          placeholder="username"
           name="username"
+          placeholder="username"
           className="authInputBox"
           value={authData.username}
-          onChange={(event) => handleRequestUsernameData(event.target.value)}
+          onChange={(event) =>
+            handleRequestAuthData(USERNAME, event.target.value)
+          }
         />
       </InputWrapper>
       <InputWrapper>
-        <label htmlFor="password">Password</label>
+        <label htmlFor="password">Password:</label>
         <input
           type={shouldShowPassword ? "text" : "password"}
-          placeholder="password"
           name="password"
+          placeholder="password"
           className="authInputBox"
           value={authData.password}
-          onChange={(event) => handleRequestPasswordData(event.target.value)}
+          onChange={(event) =>
+            handleRequestAuthData(PASSWORD, event.target.value)
+          }
         />
       </InputWrapper>
       <InputWrapper>
-        <input type="checkbox" onChange={handlePasswordDisplayOption} />
+        <input
+          type="checkbox"
+          checked={shouldShowPassword}
+          onChange={handleShouldShowPassword}
+        />
         <label>Show Password</label>
       </InputWrapper>
     </Wrapper>

--- a/app/features/Request/Body/RequestBodyRawOptions.js
+++ b/app/features/Request/Body/RequestBodyRawOptions.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled from "styled-components";
+import shallow from "zustand/shallow";
+
+import SelectWrapper from "../../../components/SelectWrapper";
+import {
+  NONE,
+  RAW,
+  REQUEST_BODY_RAW_OPTIONS,
+} from "../../../constants/request";
+import useKeyValueTableStore from "../../../store/useKeyValueTableStore";
+import useRequestStore from "../../../store/useRequestStore";
+
+const RequestBodyRawOptions = () => {
+  const { bodyRawOption, handleBodyRawOption } = useRequestStore(
+    (state) => ({
+      bodyRawOption: state.bodyRawOption,
+      bodyRawData: state.bodyRawData,
+      handleBodyRawOption: state.handleBodyRawOption,
+    }),
+    shallow,
+  );
+  const { addRequestBodyHeaders, removeRequestBodyHeaders } =
+    useKeyValueTableStore(
+      (state) => ({
+        addRequestBodyHeaders: state.addRequestBodyHeaders,
+        removeRequestBodyHeaders: state.removeRequestBodyHeaders,
+      }),
+      shallow,
+    );
+
+  const handleBodyRawSelectOption = (event) => {
+    const selectedOptionIndex = event.target.selectedIndex;
+    const selectedOptionElement = event.target.childNodes[selectedOptionIndex];
+
+    handleBodyRawOption(event.target.value);
+
+    if (event.target.value === NONE) {
+      removeRequestBodyHeaders();
+    } else {
+      removeRequestBodyHeaders();
+      addRequestBodyHeaders(selectedOptionElement.getAttribute("header-type"));
+    }
+  };
+
+  return (
+    <SelectWrapper primary>
+      <SelectOptionWrapper
+        onChange={handleBodyRawSelectOption}
+        value={bodyRawOption}
+      >
+        {REQUEST_BODY_RAW_OPTIONS.map(({ option, headerField }, index) => (
+          <option key={RAW + index} header-type={headerField} value={option}>
+            {option}
+          </option>
+        ))}
+      </SelectOptionWrapper>
+    </SelectWrapper>
+  );
+};
+
+const SelectOptionWrapper = styled.select`
+  width: 8.3rem;
+  height: 2.3rem;
+  margin-left: 1rem;
+  padding-left: 0.7rem;
+  border: 0.1rem solid rgba(255, 255, 255, 0.3);
+  border-radius: 0.25rem;
+  font-size: 1rem;
+  font-weight: 500;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.78);
+`;
+
+export default RequestBodyRawOptions;

--- a/app/features/Request/Body/RequestBodySelectMenu.js
+++ b/app/features/Request/Body/RequestBodySelectMenu.js
@@ -3,20 +3,29 @@ import styled from "styled-components";
 import shallow from "zustand/shallow";
 
 import SelectWrapper from "../../../components/SelectWrapper";
-import { NONE, REQUEST_BODY_OPTIONS } from "../../../constants/request";
+import {
+  NONE,
+  RAW,
+  REQUEST_BODY_OPTIONS,
+  REQUEST_BODY_RAW_OPTIONS,
+} from "../../../constants/request";
 import { BODY } from "../../../constants/shared";
 import useKeyValueTableStore from "../../../store/useKeyValueTableStore";
 import useRequestStore from "../../../store/useRequestStore";
-import RequestBodySelectMenuOption from "./RequestBodySelectMenuOption";
+import RequestBodyFormatButton from "../Button/RequestBodyFormatButton";
+import RequestBodyRawOptions from "./RequestBodyRawOptions";
+import RequestBodyMenuOption from "./RequestBodySelectMenuOption";
 
 const RequestBodySelectMenu = () => {
-  const { bodyOption, handleRequestBodyOption } = useRequestStore(
-    (state) => ({
-      bodyOption: state.bodyOption,
-      handleRequestBodyOption: state.handleRequestBodyOption,
-    }),
-    shallow,
-  );
+  const { bodyOption, bodyRawOption, handleRequestBodyOption } =
+    useRequestStore(
+      (state) => ({
+        bodyOption: state.bodyOption,
+        bodyRawOption: state.bodyRawOption,
+        handleRequestBodyOption: state.handleRequestBodyOption,
+      }),
+      shallow,
+    );
 
   const { addRequestBodyHeaders, removeRequestBodyHeaders } =
     useKeyValueTableStore(
@@ -26,6 +35,10 @@ const RequestBodySelectMenu = () => {
       }),
       shallow,
     );
+
+  const rawOptionHeaderField = REQUEST_BODY_RAW_OPTIONS.filter(
+    (rawOption) => rawOption.option === bodyRawOption,
+  );
 
   const handleBodyOptionChoice = (event) => {
     handleRequestBodyOption(event.target.value);
@@ -48,14 +61,24 @@ const RequestBodySelectMenu = () => {
               name="bodyOption"
               checked={bodyOption === option}
               value={option}
-              header-type={headerField}
+              header-type={
+                option === RAW
+                  ? rawOptionHeaderField[0].headerField
+                  : headerField
+              }
               onChange={handleBodyOptionChoice}
             />
             <label htmlFor={option}>{option}</label>
           </RadioInputWrapper>
         ))}
+        {bodyOption === RAW && (
+          <>
+            <RequestBodyRawOptions />
+            <RequestBodyFormatButton />
+          </>
+        )}
       </SelectWrapper>
-      <RequestBodySelectMenuOption />
+      <RequestBodyMenuOption />
     </>
   );
 };

--- a/app/features/Request/Body/RequestBodySelectMenuOption.js
+++ b/app/features/Request/Body/RequestBodySelectMenuOption.js
@@ -2,6 +2,7 @@ import React from "react";
 import shallow from "zustand/shallow";
 
 import { FORM_DATA, FORM_URLENCODED, RAW } from "../../../constants/request";
+import CodeEditor from "../../../shared/CodeEditor";
 import KeyValueTable from "../../../shared/KeyValueTable";
 import useKeyValueTableStore from "../../../store/useKeyValueTableStore";
 import useRequestStore from "../../../store/useRequestStore";
@@ -9,10 +10,16 @@ import RequestNoBody from "./RequestNoBody";
 
 const RequestBodySelectMenuOption = () => {
   const keyValueProps = useKeyValueTableStore();
-  const { bodyOption } = useRequestStore(
+  const { bodyOption, codeEditorProps } = useRequestStore(
     (state) => ({
       bodyOption: state.bodyOption,
-      bodyRawData: state.bodyRawData,
+      codeEditorProps: {
+        bodyRawOption: state.bodyRawOption.toLowerCase(),
+        bodyRawData: state.bodyRawData,
+        handleBodyRawOptionData: state.handleBodyRawOptionData,
+        shouldBeautifyEditor: state.shouldBeautifyEditor,
+        handleBeautifyButton: state.handleBeautifyButton,
+      },
     }),
     shallow,
   );
@@ -28,7 +35,7 @@ const RequestBodySelectMenuOption = () => {
         />
       );
     case RAW:
-      return <h1>Raw</h1>;
+      return <CodeEditor {...codeEditorProps} requestForm />;
 
     default:
       return <RequestNoBody />;

--- a/app/features/Request/Button/RequestBodyFormatButton.js
+++ b/app/features/Request/Button/RequestBodyFormatButton.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+import Button from "../../../components/Button";
+import useRequestStore from "../../../store/useRequestStore";
+
+const RequestBodyFormatButton = () => {
+  const handleBeautifyButton = useRequestStore(
+    (state) => state.handleBeautifyButton,
+  );
+
+  return (
+    <Button buttonPurpose="format" handleButtonClick={handleBeautifyButton}>
+      Beautify Editor
+    </Button>
+  );
+};
+
+export default RequestBodyFormatButton;

--- a/app/features/Request/Panel/RequestPanel.js
+++ b/app/features/Request/Panel/RequestPanel.js
@@ -29,6 +29,7 @@ const RequestPanel = () => {
       authOption: state.authOption,
       authData: state.authData,
       bodyOption: state.bodyOption,
+      bodyRawOption: state.bodyRawOption,
       bodyRawData: state.bodyRawData,
     }),
     shallow,

--- a/app/shared/KeyValueTable.js
+++ b/app/shared/KeyValueTable.js
@@ -16,7 +16,6 @@ const KeyValueTable = ({
   deleteTableRow,
   readOnly,
 }) => {
-  console.log(keyValueTableData);
   return (
     <TableContainerWrapper>
       <TableContainer readOnlyMode={readOnly}>

--- a/app/store/useKeyValueTableStore.js
+++ b/app/store/useKeyValueTableStore.js
@@ -6,6 +6,7 @@ import {
   ANY_MIME_TYPE,
   CACHE_CONTROL,
   CONNECTION,
+  CONTENT_TYPE,
   DEFLATE,
   FORM_DATA,
   FORM_URLENCODED,
@@ -52,6 +53,7 @@ const initialState = [
     value: KEEP_ALIVE,
     description: "",
   },
+
   {
     optionType: HEADERS,
     isChecked: false,
@@ -107,6 +109,28 @@ const useKeyValueTableStore = create((set) => ({
         dataIndex === index ? { ...tableData, description: detail } : tableData,
       ),
     })),
+
+  addRequestBodyHeaders: (headerValue) =>
+    set((state) => ({
+      keyValueTableData: [
+        {
+          optionType: HEADERS,
+          isChecked: true,
+          key: CONTENT_TYPE,
+          value: headerValue,
+          description: "",
+        },
+        ...state.keyValueTableData,
+      ],
+    })),
+
+  removeRequestBodyHeaders: () => {
+    set((state) => ({
+      keyValueTableData: state.keyValueTableData.filter(
+        (keyValueData) => keyValueData.key !== CONTENT_TYPE,
+      ),
+    }));
+  },
 
   addNewTableRow: (type) =>
     set((state) => ({

--- a/app/store/useRequestStore.js
+++ b/app/store/useRequestStore.js
@@ -10,6 +10,10 @@ const initialState = {
   authOption: NO_AUTH,
   authData: { username: "", password: "", token: "" },
   bodyOption: NONE,
+  bodyRawOption: "Text",
+  bodyRawData: { text: "", javascript: "", json: "", html: "" },
+  shouldBeautifyEditor: false,
+  shouldShowPassword: false,
 };
 
 const useRequestStore = create((set) => ({
@@ -20,6 +24,10 @@ const useRequestStore = create((set) => ({
   authOption: initialState.authOption,
   authData: initialState.authData,
   bodyOption: initialState.bodyOption,
+  bodyRawOption: initialState.bodyRawOption,
+  bodyRawData: initialState.bodyRawData,
+  shouldShowPassword: initialState.shouldShowPassword,
+  shouldBeautifyEditor: initialState.shouldBeautifyEditor,
 
   handleRequestUrlChange: (url) => set(() => ({ requestUrl: url })),
 
@@ -32,31 +40,28 @@ const useRequestStore = create((set) => ({
 
   handleRequestAuthType: (type) => set(() => ({ authOption: type })),
 
-  handleRequestUsernameData: (data) =>
+  handleRequestAuthData: (authType, data) =>
     set((state) => ({
       authData: {
         ...state.authData,
-        username: data,
-      },
-    })),
-
-  handleRequestPasswordData: (data) =>
-    set((state) => ({
-      authData: {
-        ...state.authData,
-        password: data,
-      },
-    })),
-
-  handleRequestTokenData: (data) =>
-    set((state) => ({
-      authData: {
-        ...state.authData,
-        token: data,
+        [authType]: data,
       },
     })),
 
   handleRequestBodyOption: (type) => set(() => ({ bodyOption: type })),
+
+  handleBodyRawOption: (option) => set(() => ({ bodyRawOption: option })),
+
+  handleBodyRawOptionData: (rawOption, data) =>
+    set((state) => ({
+      bodyRawData: { ...state.bodyRawData, [rawOption]: data },
+    })),
+
+  handleShouldShowPassword: () =>
+    set((state) => ({ shouldShowPassword: !state.shouldShowPassword })),
+
+  handleBeautifyButton: () =>
+    set((state) => ({ shouldBeautifyEditor: !state.shouldBeautifyEditor })),
 }));
 
 export default useRequestStore;


### PR DESCRIPTION
## Summary
- 재사용성 있는 컴포넌트들 스타일링 수정
- 상수 변수 파일에 추가
- 요청 보낼 때 body raw data를 코드로 적어서 보낼 수 있게 구현
- body raw 옵션은 총 4가지, text, javascript, json and html
- Request feature 전체적인 리팩토링 + 개선할 점 개선

<br>

### Preview 1
![Raw Option Demo](https://user-images.githubusercontent.com/83770081/178641998-161c347b-9705-451c-b494-696c10459806.gif)

### Preview 2
![Response menu demo](https://user-images.githubusercontent.com/83770081/178642066-e06f0c2e-c43a-4ec7-acab-98d9f60bb961.gif)


