### PR TITLE
[2022/07/16] - Sidebar Collection timestamp 버그 현상 해결

### DIFF
--- a/src/utils/filterDuplicatesFromObject.js
+++ b/src/utils/filterDuplicatesFromObject.js
@@ -8,8 +8,6 @@ const filterDuplicatesFromObject = (
     (history) => history.isUserFavorite,
   );
 
-  previousCollection?.map((history) => (history.favoritedTime = null)) || [];
-
   const filteredPreviousCollection =
     previousCollection?.filter((history) => history.id !== id) || [];
 


### PR DESCRIPTION
## Bug fix
- Sidebar History collection에서 favorite 적용된 collection이 삭제될 경우, 삭제된 favorite collection은 이상하게 timestamp 값을 19,000일로 표시되는 버그 해결.
- 문제의 원인은, 새로운 favorite collection 기록이 추가될 때, history collection에 없는 favorite collection의 시간 값을 null로 바꿔주고 있었습니다. 😖
- `src/utils/filterDuplicatesFromObject.js` 함수에서 문제의 코드 한 줄을 제거했습니다. 