### PR TITLE
[2022/07/20] - Fix response headers menu style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+#### Fix response header menu not displaying the whole header information
+
 ## 1.0.2
 
 #### README.md update

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Simply click Open Menu button or open the Command Palette and type the command b
 
 ## 🗒 Changelog
 
-#### Current version 1.0.0
+#### Current version 1.0.3
 
 Visit [here](https://github.com/REST-API-Client/API-Client-VSCode-Extension/blob/main/CHANGELOG.md) for a detailed release notes
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "REST API Client",
   "icon": "icons/images/icon.png",
   "description": "Simple and intuitive API Client made into a VSCode extension.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/REST-API-Client/API-Client-VSCode-Extension/issues"

--- a/webview/features/Response/Menu/ResponseMenuOption.js
+++ b/webview/features/Response/Menu/ResponseMenuOption.js
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import shallow from "zustand/shallow";
 
 import { COMMON, HEIGHT, OPTION, REQUEST } from "../../../constants";
@@ -27,7 +28,11 @@ const ResponseMenuOption = () => {
 
   switch (responseOption) {
     case COMMON.HEADERS:
-      return <KeyValueTable keyValueTableData={responseHeaders} readOnly />;
+      return (
+        <ResponseHeaderWrapper>
+          <KeyValueTable keyValueTableData={responseHeaders} readOnly />
+        </ResponseHeaderWrapper>
+      );
     default:
       return (
         <>
@@ -48,5 +53,10 @@ const ResponseMenuOption = () => {
       );
   }
 };
+
+const ResponseHeaderWrapper = styled.div`
+  height: 60vh;
+  overflow-y: scroll;
+`;
 
 export default ResponseMenuOption;


### PR DESCRIPTION
## Summary
- Response headers menu not displaying entire header fixed by giving a style fixed height + overflow-y scroll
