### PR TITLE
[2022/07/29] - Inject VSCode API directly into Webview 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-icons": "^4.4.0",
         "react-spinners": "^0.13.3",
         "styled-components": "^5.3.5",
+        "use-debounce": "^8.0.2",
         "uuid": "^8.3.2",
         "zustand": "^4.0.0-rc.1"
       },
@@ -11997,6 +11998,17 @@
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
+    "node_modules/use-debounce": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.2.tgz",
+      "integrity": "sha512-4yCQ4FmlmYNpcHXJk1E19chO1X58fH4+QrwKpa5nkx3d7szHR3MjheRgECLvHivp3ClUqEom+SHOGB9zBz+qlw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -21443,6 +21455,12 @@
           "dev": true
         }
       }
+    },
+    "use-debounce": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.2.tgz",
+      "integrity": "sha512-4yCQ4FmlmYNpcHXJk1E19chO1X58fH4+QrwKpa5nkx3d7szHR3MjheRgECLvHivp3ClUqEom+SHOGB9zBz+qlw==",
+      "requires": {}
     },
     "use-sync-external-store": {
       "version": "1.2.0",

--- a/src/SidebarWebViewPanel.js
+++ b/src/SidebarWebViewPanel.js
@@ -153,6 +153,13 @@ class SidebarWebViewPanel {
         </head>
         <body>
           <div id="root"></div>
+          <script nonce="${nonce}">
+          let vscode;
+
+          if (typeof acquireVsCodeApi !== "undefined") {
+            vscode = acquireVsCodeApi();
+          }
+          </script>
           <script nonce="${nonce}" src="${scriptSrc}"></script>
         </body>
       </html>`;

--- a/webview/features/Request/CodeSnippet/RequestCodeSnippet.js
+++ b/webview/features/Request/CodeSnippet/RequestCodeSnippet.js
@@ -11,7 +11,6 @@ import { COMMON, HEIGHT, OPTION } from "../../../constants";
 import CodeEditor from "../../../shared/CodeEditor";
 import useStore from "../../../store/useStore";
 import { generateSdkRequestObject } from "../../../utils";
-import vscode from "../../../vscode";
 
 const RequestCodeSnippet = () => {
   const {

--- a/webview/features/Request/Panel/RequestPanel.js
+++ b/webview/features/Request/Panel/RequestPanel.js
@@ -4,7 +4,6 @@ import shallow from "zustand/shallow";
 
 import { COMMON } from "../../../constants";
 import useStore from "../../../store/useStore";
-import vscode from "../../../vscode";
 import RequestButton from "../Button/RequestButton";
 import RequestDetailOption from "../Menu/RequestMenu";
 import RequestMethod from "../Method/RequestMethod";

--- a/webview/features/Response/Body/ResponseBodyMenu.js
+++ b/webview/features/Response/Body/ResponseBodyMenu.js
@@ -6,7 +6,6 @@ import CopyIcon from "../../../components/CopyIcon";
 import SelectWrapper from "../../../components/SelectWrapper";
 import { COMMON, OPTION, RESPONSE } from "../../../constants";
 import useStore from "../../../store/useStore";
-import vscode from "../../../vscode";
 import ResponseBodyViewOption from "./ResponseBodyMenuOption";
 
 const RequestBodyMenu = () => {

--- a/webview/features/Sidebar/Guide/SidebarGuideMenu.js
+++ b/webview/features/Sidebar/Guide/SidebarGuideMenu.js
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 
 import { SIDEBAR } from "../../../constants";
-import vscode from "../../../vscode";
 
 const SidebarGuideMenu = () => {
   const handleButtonClick = () => {

--- a/webview/features/Sidebar/Menu/SidebarMenuOption.js
+++ b/webview/features/Sidebar/Menu/SidebarMenuOption.js
@@ -3,7 +3,6 @@ import shallow from "zustand/shallow";
 
 import { REQUEST, SIDEBAR } from "../../../constants";
 import useStore from "../../../store/useStore";
-import vscode from "../../../vscode";
 import SidebarCollection from "../Collection/SidebarCollection";
 
 const SidebarMenuOption = () => {

--- a/webview/shared/KeyValueTable.js
+++ b/webview/shared/KeyValueTable.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { memo } from "react";
 import { CgAddR } from "react-icons/cg";
 import { FaTrashAlt } from "react-icons/fa";
 import styled from "styled-components";
@@ -190,4 +190,4 @@ KeyValueTable.propTypes = {
   handleRequestDescription: PropTypes.func,
 };
 
-export default KeyValueTable;
+export default memo(KeyValueTable);

--- a/webview/vscode.js
+++ b/webview/vscode.js
@@ -1,7 +1,0 @@
-let vscode;
-
-if (typeof acquireVsCodeApi !== "undefined") {
-  vscode = acquireVsCodeApi();
-}
-
-export default vscode;


### PR DESCRIPTION
## Summary
- Change how VSCode API is used within Webview
- Inject VSCode API directly inside Webview when it's being loaded for the first time
- Add React memo to KeyValueTable.js to prevent unnecessary rendering when the request menu is being updated

### Changed Webview code

```
<!DOCTYPE html>
  <html lang="en">
    <head>
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>REST API Tester Sidebar</title>
      <link href="${resetCssSrc}" rel="stylesheet">
      <link href="${mainStylesCssSrc}" rel="stylesheet">
   </head>
    <body>
      <div id="root"></div>
      <script nonce="${nonce}">
          let vscode;

          if (typeof acquireVsCodeApi !== "undefined") {
            vscode = acquireVsCodeApi();
          }
      </script>
      <script nonce="${nonce}" src="${scriptSrc}"></script>
    </body>
  </html>`
```