### PR TITLE
[2022/08/03] - Fix POST body raw data converted to JSON string before sending to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.4
+
+#### Fix POST body being converted to JSON string before sending to server
+
 ## 1.0.3
 
 #### Fix response header menu not displaying the whole header information

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-api-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "REST API Client",
   "icon": "icons/images/icon.png",
   "description": "Simple and intuitive API Client made into a VSCode extension.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/REST-API-Client/API-Client-VSCode-Extension/issues"

--- a/src/MainWebViewPanel.js
+++ b/src/MainWebViewPanel.js
@@ -183,6 +183,13 @@ class MainWebViewPanel {
         </head>
         <body>
           <div id="root"></div>
+          <script nonce="${nonce}">
+          let vscode;
+
+          if (typeof acquireVsCodeApi !== "undefined") {
+            vscode = acquireVsCodeApi();
+          }
+          </script>
           <script src="${scriptSrc}" nonce="${nonce}"></script>
         </body>
       </html>`;

--- a/src/utils/getBody.js
+++ b/src/utils/getBody.js
@@ -5,9 +5,8 @@ import { TYPE } from "../constants";
 function getBody(keyValueData, bodyOption, bodyRawOption, bodyRawData) {
   if (bodyOption === "None") return;
 
-  if (bodyOption === TYPE.BODY_RAW) {
+  if (bodyOption === TYPE.BODY_RAW)
     return bodyRawData[bodyRawOption.toLowerCase()];
-  }
 
   if (bodyOption === TYPE.BODY_FORM_DATA) {
     const formData = new FormData();

--- a/src/utils/getBody.js
+++ b/src/utils/getBody.js
@@ -4,8 +4,10 @@ import { TYPE } from "../constants";
 
 function getBody(keyValueData, bodyOption, bodyRawOption, bodyRawData) {
   if (bodyOption === "None") return;
-  if (bodyOption === TYPE.BODY_RAW)
-    return JSON.stringify(bodyRawData[bodyRawOption.toLowerCase()]);
+
+  if (bodyOption === TYPE.BODY_RAW) {
+    return bodyRawData[bodyRawOption.toLowerCase()];
+  }
 
   if (bodyOption === TYPE.BODY_FORM_DATA) {
     const formData = new FormData();


### PR DESCRIPTION
## Summary
Fix issue submitted by SAPikachu issue thread.

## Bug 
POST body raw data was being converted to a string by JSON.stringify forcing it to be converted to string unnecessarily before sending it to the server.