### PR TITLE
[2022/08/08] - Delete unnecessary file and add eslint settings to parse JSX

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,10 +11,13 @@
   "parserOptions": {
     "ecmaVersion": 2018,
     "requireConfigFile": false,
+    "sourceType": "module",
+    "babelOptions": {
+      "presets": ["@babel/preset-react"]
+    },
     "ecmaFeatures": {
       "jsx": true
-    },
-    "sourceType": "module"
+    }
   },
   "plugins": ["simple-import-sort", "react", "jest"],
   "extends": ["plugin:react/recommended", "plugin:jest/recommended"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const webpack = require("webpack");
 
-const commonRules = {
+const babelCommonRules = {
   loader: "babel-loader",
   options: {
     presets: ["@babel/preset-env", "@babel/preset-react"],
@@ -70,7 +70,7 @@ const mainWebViewConfig = {
       {
         test: /\.(js)$/,
         exclude: path.resolve(__dirname, "node_modules"),
-        use: commonRules,
+        use: babelCommonRules,
       },
     ],
   },
@@ -91,7 +91,7 @@ const sidebarWebViewConfig = {
       {
         test: /\.(js)$/,
         exclude: path.resolve(__dirname, "node_modules"),
-        use: commonRules,
+        use: babelCommonRules,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Remove .babelrc
- Add eslint settings to parse JSX
- Change common babel loader rules variable name
