### PR TITLE
feat: Add global CSS style 

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -92,3 +92,8 @@ textarea::placeholder {
 table {
   border: var(--default-border-size) solid var(--border);
 }
+
+a{
+  background-color: var(--vscode-editor-background);
+  color: var(--vscode-textLink-foreground);
+}

--- a/webview/features/Request/Authorization/RequestAuthSelectMenu.js
+++ b/webview/features/Request/Authorization/RequestAuthSelectMenu.js
@@ -45,8 +45,6 @@ const OptionWrapper = styled.select`
   border-radius: 0.25rem;
   font-size: 1.1rem;
   font-weight: 600;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.78);
 `;
 
 export default RequestAuthSelectMenu;

--- a/webview/features/Request/Body/RequestBodyRawOptions.js
+++ b/webview/features/Request/Body/RequestBodyRawOptions.js
@@ -67,8 +67,6 @@ const SelectOptionWrapper = styled.select`
   border-radius: 0.25rem;
   font-size: 1rem;
   font-weight: 500;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.78);
 `;
 
 export default RequestBodyRawOptions;

--- a/webview/features/Request/CodeSnippet/RequestCodeSnippet.js
+++ b/webview/features/Request/CodeSnippet/RequestCodeSnippet.js
@@ -167,8 +167,6 @@ const SelectOptionWrapper = styled.select`
   border-radius: 0.25rem;
   font-size: 1rem;
   font-weight: 500;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.78);
 `;
 
 export default RequestCodeSnippet;

--- a/webview/features/Request/Url/RequestUrl.js
+++ b/webview/features/Request/Url/RequestUrl.js
@@ -56,7 +56,6 @@ const RequestUrl = () => {
 const InputContainer = styled.input`
   padding-left: 1.5rem;
   font-size: 1.15rem;
-  color: rgba(255, 255, 255, 0.78);
 `;
 
 export default RequestUrl;

--- a/webview/features/Response/Body/ResponseBodyMenuOption.js
+++ b/webview/features/Response/Body/ResponseBodyMenuOption.js
@@ -52,8 +52,6 @@ const SelectOptionWrapper = styled.select`
   border-radius: 0.25rem;
   font-size: 1rem;
   font-weight: 500;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.78);
 `;
 
 export default ResponseBodyViewOption;


### PR DESCRIPTION
## Summary
When using the REST API extension text colour and background were both white resulting in not being able to see the available options. I edited all the files affected by this and removed the background and colour styles in them and added a global CSS style to change the colours based on the users vs code theme.
...
