### PR TITLE
Added HEAD and OPTIONS HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@
 ## ✨ Features
 
 - Send a request and receive a response from your desired API endpoint.
-- Five request method
+- Seven request methods
   - `GET`
   - `POST`
   - `PUT`
   - `PATCH`
   - `DELETE`
+  - `HEAD`
+  - `OPTIONS`
 - Various request options
   - Add parameter to your API endpoint
   - Add authorization option

--- a/webview/constants/options.ts
+++ b/webview/constants/options.ts
@@ -1,6 +1,6 @@
 const OPTION = {
   AUTHORIZATION_OPTIONS: ["No Auth", "Basic Auth", "Bearer Token"],
-  REQUEST_METHOD_OPTIONS: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+  REQUEST_METHOD_OPTIONS: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
   REQUEST_MENU_OPTIONS: [
     "Params",
     "Authorization",


### PR DESCRIPTION
## Summary

I was looking for a nice open source alternative for API testing inside VSCode and came across this project - which looks great! However for testing one of my projects I need the HEAD and OPTIONS HTTP methods and they were missing. I added them to the constants and tested that they work just fine.
