### PR TITLE
Workaround for ts-loader issue with webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,13 @@ const babelCommonRules = {
   },
 };
 
+const tsLoader = {
+  loader: "ts-loader",
+  options: {
+    transpileOnly: true,
+  },
+};
+
 const extensionConfig = {
   target: "node",
   entry: "./src/extension.ts",
@@ -36,7 +43,7 @@ const extensionConfig = {
       },
       {
         test: /\.tsx?$/,
-        use: "ts-loader",
+        use: [tsLoader],
         exclude: path.resolve(__dirname, "node_modules"),
       },
     ],
@@ -63,7 +70,7 @@ const mainWebViewConfig = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: "ts-loader",
+        use: [tsLoader],
         exclude: path.resolve(__dirname, "node_modules"),
       },
       {
@@ -100,7 +107,7 @@ const sidebarWebViewConfig = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: "ts-loader",
+        use: [tsLoader],
         exclude: path.resolve(__dirname, "node_modules"),
       },
       {


### PR DESCRIPTION
## Summary

While no errors get reported in VSCode when opening the project, the package script spits out a lot of TS errors during webpack doing it's work. This workaround works by adding  to the options of ts-loader so that it does not deal with TS verification. The ts-loader configuration also is now shared in all three target configs. This workaround is not optimal, however should be okay as long as code gets linted before packaging.
