### PR TITLE
ci: add automatic version bump, tagging, and publish on merge

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -8,18 +8,36 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install the dependencies
-        run: npm i
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        run: npm version patch -m "chore: release v%s [skip ci]"
+
+      - name: Push version bump and tag
+        run: git push origin main --follow-tags
 
       - name: Install vsce
-        run: npm i -g vsce
+        run: npm i -g @vscode/vsce
 
       - name: Package extension
         run: vsce package


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions (`checkout@v4`, `setup-node@v4`) and Node.js to 20
- Replace `npm i` with `npm ci` for reproducible installs
- Add `npm test` step before publishing
- Add `[skip ci]` guard to prevent workflow re-triggering on version bump commits
- Add `permissions: contents: write` so the workflow can push back to the repo
- Configure git identity as `github-actions[bot]`
- Run `npm version patch` to auto-increment the patch version, create a commit, and a git tag
- Push the version bump commit and tag to `main` before packaging and publishing
- Use `@vscode/vsce` (new scoped package name)

## Type of Change

- CI/CD or build configuration

## Testing

- [ ] Merge this PR and verify the workflow triggers on the Actions tab
- [ ] Verify a new tag (e.g., `v1.1.6`) appears in the repo
- [ ] Verify the extension is published to the VS Code Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)