### PR TITLE
fix(ci): fix YAML syntax errors in release workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     permissions:
       contents: write
@@ -31,7 +31,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version
-        run: npm version patch -m "chore: release v%s [skip ci]"
+        run: |
+          npm version patch -m "chore: release v%s [skip ci]"
 
       - name: Push version bump and tag
         run: git push origin main --follow-tags
@@ -43,6 +44,6 @@ jobs:
         run: vsce package
 
       - name: Publish to marketplace
-        run: vsce publish -p $PERSONAL_ACCESS_TOKEN
+        run: vsce publish -p "$PERSONAL_ACCESS_TOKEN"
         env:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Summary

Fixes the workflow file issue that caused the previous CI run to fail immediately (0s, no jobs started).

- **Root cause**: The colon in `"chore: release v%s [skip ci]"` was being parsed as a YAML mapping key, causing a syntax error
- Use block scalar (`|`) for the `npm version` command to avoid YAML colon parsing
- Use explicit `${{ }}` expression syntax for the `if` condition
- Quote the shell variable in `vsce publish` command (shellcheck fix)

Validated locally with `actionlint` — passes clean.

## Type of Change

- Bug fix (CI/CD)

## Testing

- [ ] Merge and verify the workflow runs successfully on the Actions tab
- [ ] Verify a new tag appears in the repo
- [ ] Verify the extension publishes to the marketplace