### PR TITLE
ci: use release PR instead of pushing directly to main

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,12 +6,13 @@ on:
       - main
 
 jobs:
-  release:
+  test-and-bump:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    if: ${{ !contains(github.event.head_commit.message, 'release/v') }}
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +20,7 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install the dependencies
+      - name: Install dependencies
         run: npm ci
 
       - name: Run tests
@@ -30,12 +31,45 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
+      - name: Bump version and create release PR
         run: |
-          npm version patch -m "chore: release v%s [skip ci]"
+          npm version patch --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          BRANCH="release/v${VERSION}"
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json
+          git commit -m "chore: release v${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create --title "chore: release v${VERSION}" --body "Automated version bump to v${VERSION}"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - name: Push version bump and tag
-        run: git push origin main --follow-tags
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.head_commit.message, 'release/v') }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Install vsce
         run: npm i -g @vscode/vsce


### PR DESCRIPTION
## Summary

Reworks the CI workflow to respect branch protection rules on `main`.

**Before:** The workflow tried to push the version bump commit directly to `main`, which failed due to branch protection (`GH006: Protected branch update failed`).

**After:** Two jobs in a single workflow:

- **`test-and-bump`** — Runs on normal pushes to main. Runs tests, bumps the patch version, creates a `release/vX.X.X` branch, and opens a PR.
- **`publish`** — Runs when a release PR is merged (detected by `release/v` in the merge commit message). Creates a git tag and publishes to the VS Code Marketplace.

## Testing

- `actionlint` passes locally
- All 42 test suites / 87 tests pass