### PR TITLE
fix(ci): force push release branch to handle retries

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -39,7 +39,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add package.json package-lock.json
           git commit -m "chore: release v${VERSION}"
-          git push origin "$BRANCH"
+          git push origin "$BRANCH" --force
           gh pr create --title "chore: release v${VERSION}" --body "Automated version bump to v${VERSION}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Adds `--force` to the release branch push so that if a previous run failed after pushing the branch (but before creating the PR), the next run can overwrite it instead of failing with `fetch first`.

One-line change: `git push origin "$BRANCH"` → `git push origin "$BRANCH" --force`