### PR TITLE
fix(ci): force push tag to handle retries

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -68,8 +68,8 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
+          git tag -f "v${VERSION}"
+          git push origin "v${VERSION}" --force
 
       - name: Install vsce
         run: npm i -g @vscode/vsce


### PR DESCRIPTION
## Summary

The `v1.1.6` tag was left over from a previous failed run, causing the publish job to fail with "tag already exists". 

Adds `--force` to both `git tag` and `git push` for tags, matching the same fix already applied to the release branch push.

I also deleted the stale `v1.1.6` tag from the remote.